### PR TITLE
Improved email title

### DIFF
--- a/comment_template.html
+++ b/comment_template.html
@@ -28,6 +28,7 @@
 	</p>
 	<form id="commentform" method="POST" action="{{site.url}}/commentsubmit.php">
 		<input type="hidden" name="post_id" value="{{page.id}}" />
+		<input type="hidden" name="post_title" value="{{ page.title | escape }}" />
 		<input type="hidden" name="return_url" value="{{site.url}}{{page.url}}" />
 		<table>
 			<tr>

--- a/commentsubmit.php
+++ b/commentsubmit.php
@@ -47,7 +47,21 @@ function get_post_field($key, $defaultValue = "")
 	return (isset($_POST[$key]) && !empty($_POST[$key])) ? $_POST[$key] : $defaultValue;
 }
 
-$COMMENTER_NAME = get_post_field('name', "Anonymous");
+function filter_name($input)
+{
+	$rules = array( "\r" => '', "\n" => '', "\t" => '', '"'  => "'", '<'  => '[', '>'  => ']' );
+	return trim(strtr($input, $rules));
+}
+
+function filter_email($input)
+{
+	$rules = array( "\r" => '', "\n" => '', "\t" => '', '"'  => '', ','  => '', '<'  => '', '>'  => '' );
+	return strtr($input, $rules);
+}
+
+
+$EMAIL_ADDRESS = filter_email($EMAIL_ADDRESS);
+$COMMENTER_NAME = filter_name(get_post_field('name', "Anonymous"));
 
 $subject = $SUBJECT;
 

--- a/commentsubmit.php
+++ b/commentsubmit.php
@@ -42,6 +42,13 @@ $COMMENT_RECEIVED = "comment_received.html";
  * HERE BE CODE
  ****************************************************************************/
 
+function get_post_field($key, $defaultValue = "")
+{
+	return (isset($_POST[$key]) && !empty($_POST[$key])) ? $_POST[$key] : $defaultValue;
+}
+
+$COMMENTER_NAME = get_post_field('name', "Anonymous");
+
 $subject = $SUBJECT;
 
 // NOTE: Uses the "blog owner's" email address for the "From:" field, 

--- a/commentsubmit.php
+++ b/commentsubmit.php
@@ -67,7 +67,7 @@ $subject = $SUBJECT;
 
 // NOTE: Uses the "blog owner's" email address for the "From:" field, 
 // not the email address of the commenter.
-$headers = "From: $EMAIL_ADDRESS\r\n";
+$headers = "From: $COMMENTER_NAME <$EMAIL_ADDRESS>\r\n";
 
 $post_id = $_POST["post_id"];
 unset($_POST["post_id"]);

--- a/commentsubmit.php
+++ b/commentsubmit.php
@@ -42,10 +42,16 @@ $COMMENT_RECEIVED = "comment_received.html";
  * HERE BE CODE
  ****************************************************************************/
 
+$subject = $SUBJECT;
+
+// NOTE: Uses the "blog owner's" email address for the "From:" field, 
+// not the email address of the commenter.
+$headers = "From: $EMAIL_ADDRESS\r\n";
+
 $post_id = $_POST["post_id"];
 unset($_POST["post_id"]);
-$msg = "post_id: $post_id\n";
-$msg .= "date: " . date($DATE_FORMAT) . "\n";
+$message = "post_id: $post_id\n";
+$message .= "date: " . date($DATE_FORMAT) . "\n";
 
 foreach ($_POST as $key => $value) {
 	if (strstr($value, "\n") != "") {
@@ -56,10 +62,10 @@ foreach ($_POST as $key => $value) {
 	// It's easier just to single-quote everything than to try and work
 	// out what might need quoting
 	$value = "'" . str_replace("'", "''", $value) . "'";
-	$msg .= "$key: $value\n";
+	$message .= "$key: $value\n";
 }
 
-if (mail($EMAIL_ADDRESS, $SUBJECT, $msg, "From: $EMAIL_ADDRESS"))
+if (mail($EMAIL_ADDRESS, $subject, $message, $headers))
 {
 	include $COMMENT_RECEIVED;
 }

--- a/commentsubmit.php
+++ b/commentsubmit.php
@@ -27,12 +27,6 @@ $DATE_FORMAT = "Y-m-d H:i";
 // because that turns you into an open relay, and that's not cool.
 $EMAIL_ADDRESS = "blogger@example.com";
 
-// The subject of all blog comment e-mails.  If you're running lots of these,
-// you might want to customise it, or if you were running a generic comment
-// handler you could take it out of the form, but really, who cares what your
-// comment e-mails are titled, as long as you can recognise it?
-$SUBJECT = "Blog comment received";
-
 // The contents of the following file (relative to this PHP file) will be
 // displayed after the comment is received.  Customise it to your heart's
 // content.
@@ -62,8 +56,9 @@ function filter_email($input)
 
 $EMAIL_ADDRESS = filter_email($EMAIL_ADDRESS);
 $COMMENTER_NAME = filter_name(get_post_field('name', "Anonymous"));
+$POST_TITLE = get_post_field('post_title', "Unknown post");
 
-$subject = $SUBJECT;
+$subject = "Comment from $COMMENTER_NAME on '$POST_TITLE'";
 
 // NOTE: Uses the "blog owner's" email address for the "From:" field, 
 // not the email address of the commenter.


### PR DESCRIPTION
The title of the email sent out by `commentsubmit.php` has been improved to 

> Comment from [name] on '[post title]'

making it easier to sort out when it gets to the inbox.
