### PR TITLE
Fix for Issue #9

### DIFF
--- a/commentsubmit.php
+++ b/commentsubmit.php
@@ -59,6 +59,8 @@ foreach ($_POST as $key => $value) {
 	$msg .= "$key: $value\n";
 }
 
+$msg = utf8_decode($msg);
+
 if (mail($EMAIL_ADDRESS, $SUBJECT, $msg, "From: $EMAIL_ADDRESS"))
 {
 	include $COMMENT_RECEIVED;


### PR DESCRIPTION
Decodes from `UTF-8` character formatting allowing characters from non-English languages to show up properly in `ISO-8859-1`.
