### PR TITLE
Fix compatibility with Jekyll >= 1.1.0

### DIFF
--- a/static_comments.rb
+++ b/static_comments.rb
@@ -21,8 +21,8 @@
 class Jekyll::Post
 	alias :to_liquid_without_comments :to_liquid
 	
-	def to_liquid
-		data = to_liquid_without_comments
+	def to_liquid(attrs = nil)
+		data = to_liquid_without_comments(attrs)
 		data['comments'] = StaticComments::find_for_post(self)
 		data['comment_count'] = data['comments'].length
 		data

--- a/static_comments.rb
+++ b/static_comments.rb
@@ -22,7 +22,7 @@ class Jekyll::Post
 	alias :to_liquid_without_comments :to_liquid
 	
 	def to_liquid(attrs = nil)
-		data = to_liquid_without_comments(attrs)
+		data = (attrs.nil? ? to_liquid_without_comments() : to_liquid_without_comments(attrs))
 		data['comments'] = StaticComments::find_for_post(self)
 		data['comment_count'] = data['comments'].length
 		data


### PR DESCRIPTION
Adds an additional argument added in a newer Jekyll version. Luckily,
since the value is optional, this plugin is still compatible with older
versions of Jekyll.

Fixes https://github.com/mpalmer/jekyll-static-comments/issues/13
